### PR TITLE
Remove submodule init + update from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,6 @@ COPY --chown=rstudio:rstudio . /home/rstudio/
 
 RUN apt-get update --fix-missing && apt-get install -yq libssl-dev libpng-dev libnetcdf-dev libxml2-dev libxt6 libharfbuzz-dev libfribidi-dev libv8-dev 
 
-## get submodules
-
-RUN git submodule init
-RUN git submodule update
-
 ## install R package and dependencies
 
 RUN Rscript -e "install.packages('devtools', ask=FALSE, Ncpus=max(1, parallel::detectCores(), na.rm=TRUE))"


### PR DESCRIPTION
If we copy all files over with `COPY --chown=rstudio:rstudio . /home/rstudio/`, do we still need `RUN git submodule init` and `RUN git submodule update`?

```
# Dockerfile
FROM rocker/tidyverse:4.0.2
WORKDIR /home/rstudio
COPY --chown=rstudio:rstudio . /home/rstudio/

RUN apt-get update --fix-missing && apt-get install -yq libssl-dev libpng-dev libnetcdf-dev libxml2-dev libxt6 libharfbuzz-dev libfribidi-dev libv8-dev 

## get submodules

RUN git submodule init
RUN git submodule update

## install R package and dependencies

RUN Rscript -e "install.packages('devtools', ask=FALSE, Ncpus=max(1, parallel::detectCores(), na.rm=TRUE))"
```

This is related to #1, which is still having an issue with the `/home/rstudio` inside the Docker container not being a safe path.